### PR TITLE
Be more explicit about breaking the system.

### DIFF
--- a/apt-private/private-install.cc
+++ b/apt-private/private-install.cc
@@ -312,10 +312,10 @@ bool InstallPackages(CacheFile &Cache, APT::PackageVector &HeldBackPackages, boo
 
          // TRANSLATOR: This string needs to be typed by the user as a confirmation, so be
          //             careful with hard to type or special characters (like non-breaking spaces)
-         const char *Prompt = _("Yes, do as I say!");
+         const char *Prompt = _("Do as I say! Break my system!");
          std::string question;
          strprintf(question,
-            _("You are about to do something potentially harmful.\n"
+            _("You are about to do something that will break your system.\n"
                "To continue type in the phrase '%s'\n"
                " ?] "), Prompt);
          if (AnalPrompt(question, Prompt) == false) {


### PR DESCRIPTION
This changes the prompt to be much more explicit about the potential harm caused by removing essential system packages.

Before this change (with `/etc/apt/break-my-system` present):

    $ sudo apt remove pop-desktop
    Reading package list... Done
    Building dependency tree... Done
    [wall of text]
    0 upgraded, 0 newly installed, 1 to remove and 1 not upgraded.
    After this operation, 8,192 B disk space will be freed.
    You are about to do something potentially harmful.
    To continue type in the phrase 'Yes, do as I say!'
     ?]

After this change (with `/etc/apt/break-my-system` present):

    $ sudo apt remove pop-desktop
    Reading package list... Done
    Building dependency tree... Done
    [wall of text]
    0 upgraded, 0 newly installed, 1 to remove and 1 not upgraded.
    After this operation, 8,192 B disk space will be freed.
    You are about to do something that will break your system.
    To continue type in the phrase 'Do as I say! Break my system!'
     ?]

The `Do as I say!` part has been kept to improve googleability.